### PR TITLE
Let the user select how many comments should be fetched and displayed

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
@@ -30,11 +30,19 @@ import java.util.List;
 import static com.google.sps.utils.Constants.COMMENT_COMMENTER;
 import static com.google.sps.utils.Constants.COMMENT_CONTENT;
 import static com.google.sps.utils.Constants.COMMENT_KEY;
+import static com.google.sps.utils.Constants.COMMENT_MAXNUMBER;
 import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
 
 /** Servlet that handles getting and posting comment content. */
 @WebServlet("/comment")
 public final class CommentServlet extends HttpServlet {
+
+  private int maxNumberOfComments;
+
+  @Override
+  public void init() {
+    this.maxNumberOfComments = 10; // default value
+  }
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -57,13 +65,17 @@ public final class CommentServlet extends HttpServlet {
 
     List<Comment> comments = new ArrayList<>();
     for (Entity entity: results.asIterable()) {
+      if (comments.size() > this.maxNumberOfComments) {
+        break;
+      }
+
       // Loads comments from Datastore
       Comment comment = Comment.CREATOR.fromEntity(entity);
       comments.add(comment);
     }
+
     return comments;
   }
-
 
   /** Converts the list of Comment objecct into json form */
   private String convertToJsonUsingGson(List<Comment> comments) {
@@ -83,6 +95,11 @@ public final class CommentServlet extends HttpServlet {
     // Gets comments from the form
     String commenter = getParameter(request, /*name=*/COMMENT_COMMENTER, /*defaultValue=*/"");
     String content = getParameter(request, /*name=*/COMMENT_CONTENT, /*defaultValue=*/"No comments");
+
+    String maxNumOfCommentStr = getParameter(request, /*name=*/COMMENT_MAXNUMBER, "10");
+    if (maxNumOfCommentStr != null) {
+      this.maxNumberOfComments = Integer.parseInt(maxNumOfCommentStr);
+    }
     // TODO: validate request parameters
 
     // Stores the comment into the Datastore

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
@@ -33,73 +33,68 @@ import static com.google.sps.utils.Constants.COMMENT_KEY;
 import static com.google.sps.utils.Constants.COMMENT_MAXNUMBER;
 import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
 
-/** Servlet that handles getting and posting comment content. */
+/** Servlet that handles getting comment content. */
 @WebServlet("/comment")
 public final class CommentServlet extends HttpServlet {
 
-  private int maxNumberOfComments;
+//  private int maxNumberOfComments;
+//
+//  @Override
+//  public void init() {
+//    this.maxNumberOfComments = 10; // default value
+//  }
+//
+//  @Override
+//  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+//    // Loads the comment from Datastore
+//    List<Comment> comments = getComments();
+//
+//    // Converts into json form
+//    String json = convertToJsonUsingGson(comments);
+//
+//    // Sends the JSON as the response
+//    sendJsonResponse(response, json);
+//  }
 
-  @Override
-  public void init() {
-    this.maxNumberOfComments = 10; // default value
-  }
-  
-  @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Loads the comment from Datastore
-    List<Comment> comments = getComments();
-
-    // Converts into json form
-    String json = convertToJsonUsingGson(comments);
-
-    // Sends the JSON as the response
-    sendJsonResponse(response, json);
-  }
-
-  /** Loads the comment from Datastore */
-  private List<Comment> getComments() {
-    Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
-
-    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
-    PreparedQuery results = datastoreService.prepare(query);
-
-    List<Comment> comments = new ArrayList<>();
-    for (Entity entity: results.asIterable()) {
-      if (comments.size() > this.maxNumberOfComments) {
-        break;
-      }
-
-      // Loads comments from Datastore
-      Comment comment = Comment.CREATOR.fromEntity(entity);
-      comments.add(comment);
-    }
-
-    return comments;
-  }
-
-  /** Converts the list of Comment objecct into json form */
-  private String convertToJsonUsingGson(List<Comment> comments) {
-    Gson gson = new Gson();
-    String json = gson.toJson(comments);
-    return json;
-  }
-
-  /** Sends the JSON as response */
-  private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
-    response.setContentType("application/json;");
-    response.getWriter().println(json);
-  }
+//  /** Loads the comment from Datastore */
+//  private List<Comment> getComments() {
+//    Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
+//
+//    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+//    PreparedQuery results = datastoreService.prepare(query);
+//
+//    List<Comment> comments = new ArrayList<>();
+//    for (Entity entity: results.asIterable()) {
+//      if (comments.size() > this.maxNumberOfComments) {
+//        break;
+//      }
+//
+//      // Loads comments from Datastore
+//      Comment comment = Comment.CREATOR.fromEntity(entity);
+//      comments.add(comment);
+//    }
+//
+//    return comments;
+//  }
+//
+//  /** Converts the list of Comment objecct into json form */
+//  private String convertToJsonUsingGson(List<Comment> comments) {
+//    Gson gson = new Gson();
+//    String json = gson.toJson(comments);
+//    return json;
+//  }
+//
+//  /** Sends the JSON as response */
+//  private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
+//    response.setContentType("application/json;");
+//    response.getWriter().println(json);
+//  }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Gets comments from the form
     String commenter = getParameter(request, /*name=*/COMMENT_COMMENTER, /*defaultValue=*/"");
     String content = getParameter(request, /*name=*/COMMENT_CONTENT, /*defaultValue=*/"No comments");
-
-    String maxNumOfCommentStr = getParameter(request, /*name=*/COMMENT_MAXNUMBER, "10");
-    if (maxNumOfCommentStr != null) {
-      this.maxNumberOfComments = Integer.parseInt(maxNumOfCommentStr);
-    }
     // TODO: validate request parameters
 
     // Stores the comment into the Datastore

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
@@ -1,129 +1,18 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package com.google.sps.servlets;
 
-import com.google.appengine.api.datastore.*;
-import com.google.gson.Gson;
-import com.google.sps.data.Comment;
-
-import java.io.IOException;
-import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.google.sps.utils.Constants.COMMENT_COMMENTER;
-import static com.google.sps.utils.Constants.COMMENT_CONTENT;
-import static com.google.sps.utils.Constants.COMMENT_KEY;
-import static com.google.sps.utils.Constants.COMMENT_MAXNUMBER;
-import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
-
-/** Servlet that handles getting comment content. */
-@WebServlet("/comment")
-public final class CommentServlet extends HttpServlet {
-
-//  private int maxNumberOfComments;
-//
-//  @Override
-//  public void init() {
-//    this.maxNumberOfComments = 10; // default value
-//  }
-//
-//  @Override
-//  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-//    // Loads the comment from Datastore
-//    List<Comment> comments = getComments();
-//
-//    // Converts into json form
-//    String json = convertToJsonUsingGson(comments);
-//
-//    // Sends the JSON as the response
-//    sendJsonResponse(response, json);
-//  }
-
-//  /** Loads the comment from Datastore */
-//  private List<Comment> getComments() {
-//    Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
-//
-//    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
-//    PreparedQuery results = datastoreService.prepare(query);
-//
-//    List<Comment> comments = new ArrayList<>();
-//    for (Entity entity: results.asIterable()) {
-//      if (comments.size() > this.maxNumberOfComments) {
-//        break;
-//      }
-//
-//      // Loads comments from Datastore
-//      Comment comment = Comment.CREATOR.fromEntity(entity);
-//      comments.add(comment);
-//    }
-//
-//    return comments;
-//  }
-//
-//  /** Converts the list of Comment objecct into json form */
-//  private String convertToJsonUsingGson(List<Comment> comments) {
-//    Gson gson = new Gson();
-//    String json = gson.toJson(comments);
-//    return json;
-//  }
-//
-//  /** Sends the JSON as response */
-//  private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
-//    response.setContentType("application/json;");
-//    response.getWriter().println(json);
-//  }
-
-  @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Gets comments from the form
-    String commenter = getParameter(request, /*name=*/COMMENT_COMMENTER, /*defaultValue=*/"");
-    String content = getParameter(request, /*name=*/COMMENT_CONTENT, /*defaultValue=*/"No comments");
-    // TODO: validate request parameters
-
-    // Stores the comment into the Datastore
-    storeComment(commenter, content);
-
-    // Redirects back to the HTML page.
-    response.sendRedirect("/index.html");
-  }
-
-  /** Stores the comment into the Datastore */
-  private void storeComment(String commenter, String content) {
-    // create a miscellaneous comment object to convert it to entity
-    long timestamp = System.currentTimeMillis();
-    Comment comment = new Comment(0, commenter, content, timestamp);
-
-    // put the entity into Datastore
-    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
-    datastoreService.put(comment.toEntity(COMMENT_KEY));
-  }
-
-  /**
-   * @return the value of parameter with the {@code name} in the {@code request}
-   *         or returns {@code defaultValue} if that parameter does not exist.
-   */
-  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
-    String value = request.getParameter(name);
-    if (value == null) {
-      return defaultValue;
+public class CommentServlet extends HttpServlet {
+    /**
+     * @return the value of parameter with the {@code name} in the {@code request}
+     *         or returns {@code defaultValue} if that parameter does not exist.
+     */
+    protected String getParameter(HttpServletRequest request, String name, String defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
     }
-    return value;
-  }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -27,17 +27,17 @@ public class ListCommentServlet extends CommentServlet {
         this.maxNumberOfComments = 10; // default value
     }
 
-    @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        // Loads the comment from Datastore
-        List<Comment> comments = getComments(request);
-
-        // Converts into json form
-        String json = convertToJsonUsingGson(comments);
-
-        // Sends the JSON as the response
-        sendJsonResponse(response, json);
-    }
+//    @Override
+//    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+//        // Loads the comment from Datastore
+//        List<Comment> comments = getComments(request);
+//
+//        // Converts into json form
+//        String json = convertToJsonUsingGson(comments);
+//
+//        // Sends the JSON as the response
+//        sendJsonResponse(response, json);
+//    }
 
     /** Loads the comment from Datastore */
     private List<Comment> getComments(HttpServletRequest request) {
@@ -86,6 +86,17 @@ public class ListCommentServlet extends CommentServlet {
             return;
         }
 
-        // response.sendRedirect("/index.html");
+        // Loads the comment from Datastore
+        List<Comment> comments = getComments(request);
+
+        // Converts into json form
+        String json = convertToJsonUsingGson(comments);
+
+        // Sends the JSON as the response
+        sendJsonResponse(response, json);
+
+        response.sendRedirect("/index.html");
+
+        // TODO: how to click a button and submit form then execute javascript function
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -71,6 +71,7 @@ public class ListCommentServlet extends CommentServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
+        this.maxNumberOfComments = 0;
     }
 
     @Override
@@ -83,7 +84,6 @@ public class ListCommentServlet extends CommentServlet {
             System.err.println("Could not convert to int: " + maxNumOfCommentStr);
             response.setContentType("text/html;");
             response.getWriter().println("Please enter an integer between 1 and 10.");
-            return;
         }
 
         response.sendRedirect("/index.html");

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -14,9 +14,11 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.util.List;
 
-/** Servlet that handles posting list of comments. */
+/** Servlet that handles getting list of comments. */
 @WebServlet("/list-comment")
 public class ListCommentServlet extends HttpServlet {
+    private static final String PARAM_NAME_QUANTITY = "quantity";
+    private static final int DEFAULT_COMMENT_QUANTITY = 0;
 
     private CommentDataStore commentDataStore;
 
@@ -24,9 +26,6 @@ public class ListCommentServlet extends HttpServlet {
     public void init() {
         this.commentDataStore = new CommentDataStore(DatastoreServiceFactory.getDatastoreService());
     }
-
-    private static final String PARAM_NAME_QUANTITY = "quantity";
-    private static final int DEFAULT_COMMENT_QUANTITY = 0;
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -43,8 +43,14 @@ public class ListCommentServlet extends HttpServlet {
 
         try {
             limit = Integer.parseInt(maxNumOfCommentStr);
+
+            if (limit < 1 || limit > 10) {
+                return 0;
+            }
         } catch (NumberFormatException e) {
             System.err.println("Could not convert to int: " + maxNumOfCommentStr);
+            response.setContentType("text/html;");
+            response.getWriter().println("Please enter an integer between 1 and 10.");
 
             return limit;
         }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -26,7 +26,7 @@ public class ListCommentServlet extends HttpServlet {
     }
 
     private static final String PARAM_NAME_QUANTITY = "quantity";
-    private static final String DEFAULT_COMMENT_QUANTITY = "0";
+    private static final int DEFAULT_COMMENT_QUANTITY = 0;
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -37,22 +37,14 @@ public class ListCommentServlet extends HttpServlet {
 
     private int getMaxNumberOfComments(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String maxNumOfCommentStr = ServletUtils.getParameter(
-                request, /*name=*/PARAM_NAME_QUANTITY, /*defaultValue=*/"10");
+                request, /*name=*/PARAM_NAME_QUANTITY, /*defaultValue=*/"0");
 
         int limit = 0;
 
         try {
             limit = Integer.parseInt(maxNumOfCommentStr);
-
-            if (limit < 1 || limit > 10) {
-                response.setContentType("application/json;");
-                response.getWriter().println("Please enter an integer between 1 and 10.");
-                return 0;
-            }
         } catch (NumberFormatException e) {
             System.err.println("Could not convert to int: " + maxNumOfCommentStr);
-            response.setContentType("application/json;");
-            response.getWriter().println("Please enter an integer between 1 and 10.");
 
             return limit;
         }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -72,6 +72,7 @@ public class ListCommentServlet extends CommentServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
+        response.sendRedirect("/index.html");
     }
 
     @Override

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -1,0 +1,75 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.*;
+import com.google.gson.Gson;
+import com.google.sps.data.Comment;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.sps.utils.Constants.COMMENT_KEY;
+import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
+
+
+/** Servlet that handles posting comment content. */
+@WebServlet("/list-comment")
+public class ListCommentServlet extends HttpServlet {
+    private int maxNumberOfComments;
+
+    @Override
+    public void init() {
+        this.maxNumberOfComments = 10; // default value
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Loads the comment from Datastore
+        List<Comment> comments = getComments();
+
+        // Converts into json form
+        String json = convertToJsonUsingGson(comments);
+
+        // Sends the JSON as the response
+        sendJsonResponse(response, json);
+    }
+
+    /** Loads the comment from Datastore */
+    private List<Comment> getComments() {
+        Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
+
+        DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+        PreparedQuery results = datastoreService.prepare(query);
+
+        List<Comment> comments = new ArrayList<>();
+        for (Entity entity: results.asIterable()) {
+            if (comments.size() > this.maxNumberOfComments) {
+                break;
+            }
+
+            // Loads comments from Datastore
+            Comment comment = Comment.CREATOR.fromEntity(entity);
+            comments.add(comment);
+        }
+
+        return comments;
+    }
+
+    /** Converts the list of Comment objecct into json form */
+    private String convertToJsonUsingGson(List<Comment> comments) {
+        Gson gson = new Gson();
+        String json = gson.toJson(comments);
+        return json;
+    }
+
+    /** Sends the JSON as response */
+    private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
+        response.setContentType("application/json;");
+        response.getWriter().println(json);
+    }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -65,9 +65,4 @@ public class ListCommentServlet extends HttpServlet {
         response.setContentType("application/json;");
         response.getWriter().println(json);
     }
-
-    @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        System.out.println("doPost is called");
-    }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -30,7 +30,6 @@ public class ListCommentServlet extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        System.out.printf("doGet is called");
         // Gets the displayed comment limit
         int limit = ServletUtils.getIntParameter(request, PARAM_NAME_QUANTITY, DEFAULT_COMMENT_QUANTITY);
         // TODO: parameter validation

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -24,20 +24,20 @@ public class ListCommentServlet extends CommentServlet {
 
     @Override
     public void init() {
-        this.maxNumberOfComments = 10; // default value
+        this.maxNumberOfComments = 0; // default value
     }
 
-//    @Override
-//    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-//        // Loads the comment from Datastore
-//        List<Comment> comments = getComments(request);
-//
-//        // Converts into json form
-//        String json = convertToJsonUsingGson(comments);
-//
-//        // Sends the JSON as the response
-//        sendJsonResponse(response, json);
-//    }
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Loads the comment from Datastore
+        List<Comment> comments = getComments(request);
+
+        // Converts into json form
+        String json = convertToJsonUsingGson(comments);
+
+        // Sends the JSON as the response
+        sendJsonResponse(response, json);
+    }
 
     /** Loads the comment from Datastore */
     private List<Comment> getComments(HttpServletRequest request) {
@@ -85,15 +85,6 @@ public class ListCommentServlet extends CommentServlet {
             response.getWriter().println("Please enter an integer between 1 and 10.");
             return;
         }
-
-        // Loads the comment from Datastore
-        List<Comment> comments = getComments(request);
-
-        // Converts into json form
-        String json = convertToJsonUsingGson(comments);
-
-        // Sends the JSON as the response
-        sendJsonResponse(response, json);
 
         response.sendRedirect("/index.html");
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -30,7 +30,7 @@ public class ListCommentServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Loads the comment from Datastore
-        List<Comment> comments = getComments();
+        List<Comment> comments = getComments(request);
 
         // Converts into json form
         String json = convertToJsonUsingGson(comments);
@@ -40,11 +40,14 @@ public class ListCommentServlet extends HttpServlet {
     }
 
     /** Loads the comment from Datastore */
-    private List<Comment> getComments() {
+    private List<Comment> getComments(HttpServletRequest request) {
         Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
 
         DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastoreService.prepare(query);
+
+        String maxNumOfCommentStr = getParameter(request, "quantity", "10");
+        this.maxNumberOfComments = Integer.parseInt(maxNumOfCommentStr);
 
         List<Comment> comments = new ArrayList<>();
         for (Entity entity: results.asIterable()) {
@@ -71,5 +74,18 @@ public class ListCommentServlet extends HttpServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
+        response.sendRedirect("/index.html");
+    }
+
+    /**
+     * @return the value of parameter with the {@code name} in the {@code request}
+     *         or returns {@code defaultValue} if that parameter does not exist.
+     */
+    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -30,6 +30,7 @@ public class ListCommentServlet extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        System.out.printf("doGet is called");
         // Gets the displayed comment limit
         int limit = ServletUtils.getIntParameter(request, PARAM_NAME_QUANTITY, DEFAULT_COMMENT_QUANTITY);
         // TODO: parameter validation
@@ -63,5 +64,10 @@ public class ListCommentServlet extends HttpServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        System.out.println("doPost is called");
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -17,14 +17,8 @@ import java.util.List;
 /** Servlet that handles posting comment content. */
 @WebServlet("/list-comment")
 public class ListCommentServlet extends HttpServlet {
-    private int maxNumberOfComments;
 
     private static final String PARAM_NAME_QUANTITY = "quantity";
-
-    @Override
-    public void init() {
-        this.maxNumberOfComments = 0; // default value
-    }
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -32,7 +26,7 @@ public class ListCommentServlet extends HttpServlet {
         int limit = getMaxNumberOfComments(request, response);
 
         // Loads the comment from Datastore
-        List<Comment> comments = getComments(request, limit);
+        List<Comment> comments = getComments(limit);
 
         // Converts into json form
         String json = convertToJsonUsingGson(comments);
@@ -50,9 +44,10 @@ public class ListCommentServlet extends HttpServlet {
         try {
             limit = Integer.parseInt(maxNumOfCommentStr);
 
-            if (this.maxNumberOfComments < 1 || this.maxNumberOfComments > 10) {
+            if (limit < 1 || limit > 10) {
                 response.setContentType("application/json;");
                 response.getWriter().println("Please enter an integer between 1 and 10.");
+                return 0;
             }
         } catch (NumberFormatException e) {
             System.err.println("Could not convert to int: " + maxNumOfCommentStr);
@@ -66,7 +61,7 @@ public class ListCommentServlet extends HttpServlet {
     }
 
     /** Loads the comment from Datastore */
-    private List<Comment> getComments(HttpServletRequest request, int limit) {
+    private List<Comment> getComments(int limit) {
         // Loads comments from Datastore
         List<Comment> comments = CommentDataStore.COMMENT_OBJECT_DATA_STORE.load(limit);
 
@@ -84,7 +79,6 @@ public class ListCommentServlet extends HttpServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
-        this.maxNumberOfComments = 0;
     }
 
     @Override

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -21,12 +21,10 @@ import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
 @WebServlet("/list-comment")
 public class ListCommentServlet extends CommentServlet {
     private int maxNumberOfComments;
-    private List<Comment> comments;
 
     @Override
     public void init() {
         this.maxNumberOfComments = 0; // default value
-        comments = new ArrayList<>();
     }
 
     @Override
@@ -48,9 +46,9 @@ public class ListCommentServlet extends CommentServlet {
         DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastoreService.prepare(query);
 
-        comments = new ArrayList<>();
+        List<Comment> comments = new ArrayList<>();
         for (Entity entity: results.asIterable()) {
-            if (comments.size() > this.maxNumberOfComments) {
+            if (comments.size() >= this.maxNumberOfComments) {
                 break;
             }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -80,6 +80,11 @@ public class ListCommentServlet extends CommentServlet {
 
         try {
             this.maxNumberOfComments = Integer.parseInt(maxNumOfCommentStr);
+
+            if (this.maxNumberOfComments < 1 || this.maxNumberOfComments > 10) {
+                response.setContentType("text/html;");
+                response.getWriter().println("Please enter an integer between 1 and 10.");
+            }
         } catch (NumberFormatException e) {
             System.err.println("Could not convert to int: " + maxNumOfCommentStr);
             response.setContentType("text/html;");

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -52,7 +52,7 @@ public class ListCommentServlet extends HttpServlet {
             response.setContentType("text/html;");
             response.getWriter().println("Please enter an integer between 1 and 10.");
 
-            return limit;
+            return 0;
         }
 
         return limit;

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -86,6 +86,6 @@ public class ListCommentServlet extends CommentServlet {
             return;
         }
 
-        response.sendRedirect("/index.html");
+        // response.sendRedirect("/index.html");
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.sps.utils.Constants.COMMENT_KEY;
+import static com.google.sps.utils.Constants.COMMENT_MAXNUMBER;
 import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
 
 
@@ -72,12 +73,12 @@ public class ListCommentServlet extends CommentServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
-        response.sendRedirect("/index.html");
+        // response.sendRedirect("/index.html");
     }
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String maxNumOfCommentStr = getParameter(request, "quantity", "10");
+        String maxNumOfCommentStr = getParameter(request, /*name=*/COMMENT_MAXNUMBER, /*defaultValue=*/"10");
 
         try {
             this.maxNumberOfComments = Integer.parseInt(maxNumOfCommentStr);

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -21,10 +21,12 @@ import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
 @WebServlet("/list-comment")
 public class ListCommentServlet extends CommentServlet {
     private int maxNumberOfComments;
+    private List<Comment> comments;
 
     @Override
     public void init() {
         this.maxNumberOfComments = 0; // default value
+        comments = new ArrayList<>();
     }
 
     @Override
@@ -46,7 +48,7 @@ public class ListCommentServlet extends CommentServlet {
         DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastoreService.prepare(query);
 
-        List<Comment> comments = new ArrayList<>();
+        comments = new ArrayList<>();
         for (Entity entity: results.asIterable()) {
             if (comments.size() > this.maxNumberOfComments) {
                 break;

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 /** Servlet that handles posting list of comments. */
-@WebServlet("/list-comment")
+@WebServlet("/list-comment*")
 public class ListCommentServlet extends HttpServlet {
 
     private CommentDataStore commentDataStore;

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -92,7 +92,5 @@ public class ListCommentServlet extends CommentServlet {
         }
 
         response.sendRedirect("/index.html");
-
-        // TODO: how to click a button and submit form then execute javascript function
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -1,5 +1,6 @@
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.gson.Gson;
 import com.google.sps.data.Comment;
 import com.google.sps.utils.CommentDataStore;
@@ -17,6 +18,13 @@ import java.util.List;
 /** Servlet that handles posting list of comments. */
 @WebServlet("/list-comment")
 public class ListCommentServlet extends HttpServlet {
+
+    private CommentDataStore commentDataStore;
+
+    @Override
+    public void init() {
+        this.commentDataStore = new CommentDataStore(DatastoreServiceFactory.getDatastoreService());
+    }
 
     private static final String PARAM_NAME_QUANTITY = "quantity";
     private static final String DEFAULT_COMMENT_QUANTITY = "0";
@@ -40,7 +48,7 @@ public class ListCommentServlet extends HttpServlet {
     /** Loads the comment from Datastore */
     private List<Comment> getComments(int limit) {
         // Loads comments from Datastore
-        List<Comment> comments = CommentDataStore.COMMENT_OBJECT_DATA_STORE.load(limit);
+        List<Comment> comments = this.commentDataStore.load(limit);
 
         return comments;
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -63,26 +63,6 @@ public class ListCommentServlet extends HttpServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
-    }
-
-    @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-//        String maxNumOfCommentStr = CommentUtils.getParameter(
-//                request, /*name=*/Constants.MAXNUMBER, /*defaultValue=*/"10");
-//
-//        try {
-//            this.maxNumberOfComments = Integer.parseInt(maxNumOfCommentStr);
-//
-//            if (this.maxNumberOfComments < 1 || this.maxNumberOfComments > 10) {
-//                response.setContentType("text/html;");
-//                response.getWriter().println("Please enter an integer between 1 and 10.");
-//            }
-//        } catch (NumberFormatException e) {
-//            System.err.println("Could not convert to int: " + maxNumOfCommentStr);
-//            response.setContentType("text/html;");
-//            response.getWriter().println("Please enter an integer between 1 and 10.");
-//        }
-
         response.sendRedirect("/index.html");
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /** Servlet that handles getting list of comments. */
 @WebServlet("/list-comment")
-public class ListCommentServlet extends HttpServlet {
+public final class ListCommentServlet extends HttpServlet {
     private static final String PARAM_NAME_QUANTITY = "quantity";
     private static final int DEFAULT_COMMENT_QUANTITY = 0;
 
@@ -34,21 +34,13 @@ public class ListCommentServlet extends HttpServlet {
         // TODO: parameter validation
 
         // Loads the comment from Datastore
-        List<Comment> comments = getComments(limit);
+        List<Comment> comments = this.commentDataStore.load(limit);
 
         // Converts into json form
         String json = convertToJsonUsingGson(comments);
 
         // Sends the JSON as the response
         sendJsonResponse(response, json);
-    }
-
-    /** Loads the comment from Datastore */
-    private List<Comment> getComments(int limit) {
-        // Loads comments from Datastore
-        List<Comment> comments = this.commentDataStore.load(limit);
-
-        return comments;
     }
 
     /** Converts the list of Comment objecct into json form */

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -14,7 +14,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.util.List;
 
-
 /** Servlet that handles posting list of comments. */
 @WebServlet("/list-comment")
 public class ListCommentServlet extends HttpServlet {

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -63,6 +63,5 @@ public class ListCommentServlet extends HttpServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
-        response.sendRedirect("/index.html");
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -5,9 +5,7 @@ import com.google.gson.Gson;
 import com.google.sps.data.Comment;
 
 import java.io.IOException;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -73,7 +71,6 @@ public class ListCommentServlet extends CommentServlet {
     private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
         response.setContentType("application/json;");
         response.getWriter().println(json);
-        // response.sendRedirect("/index.html");
     }
 
     @Override

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -14,16 +14,18 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 
-/** Servlet that handles posting comment content. */
+/** Servlet that handles posting list of comments. */
 @WebServlet("/list-comment")
 public class ListCommentServlet extends HttpServlet {
 
     private static final String PARAM_NAME_QUANTITY = "quantity";
+    private static final String DEFAULT_COMMENT_QUANTITY = "0";
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Gets the displayed comment limit
-        int limit = getMaxNumberOfComments(request, response);
+        int limit = ServletUtils.getIntParameter(request, PARAM_NAME_QUANTITY, DEFAULT_COMMENT_QUANTITY);
+        // TODO: parameter validation
 
         // Loads the comment from Datastore
         List<Comment> comments = getComments(limit);
@@ -33,29 +35,6 @@ public class ListCommentServlet extends HttpServlet {
 
         // Sends the JSON as the response
         sendJsonResponse(response, json);
-    }
-
-    private int getMaxNumberOfComments(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String maxNumOfCommentStr = ServletUtils.getParameter(
-                request, /*name=*/PARAM_NAME_QUANTITY, /*defaultValue=*/"0");
-
-        int limit = 0;
-
-        try {
-            limit = Integer.parseInt(maxNumOfCommentStr);
-
-            if (limit < 1 || limit > 10) {
-                return 0;
-            }
-        } catch (NumberFormatException e) {
-            System.err.println("Could not convert to int: " + maxNumOfCommentStr);
-            response.setContentType("text/html;");
-            response.getWriter().println("Please enter an integer between 1 and 10.");
-
-            return 0;
-        }
-
-        return limit;
     }
 
     /** Loads the comment from Datastore */

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 /** Servlet that handles posting list of comments. */
-@WebServlet(urlPatterns = {"/list-comment"})
+@WebServlet("/list-comment")
 public class ListCommentServlet extends HttpServlet {
 
     private CommentDataStore commentDataStore;

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 /** Servlet that handles posting list of comments. */
-@WebServlet("/list-comment*")
+@WebServlet(urlPatterns = {"/list-comment"})
 public class ListCommentServlet extends HttpServlet {
 
     private CommentDataStore commentDataStore;

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentServlet.java
@@ -86,6 +86,6 @@ public class ListCommentServlet extends CommentServlet {
             return;
         }
 
-        // response.sendRedirect("/index.html");
+        response.sendRedirect("/index.html");
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -31,7 +31,7 @@ public final class NewCommentServlet extends HttpServlet {
 
   private final static String PARAM_NAME_COMMENTER = "commenter";
   private final static String PARAM_NAME_CONTENT = "content";
-  private static final String DEFAULT_COMMENT_COMMENTER = "";
+  private static final String DEFAULT_COMMENT_COMMENTER = "Anonymous";
   private static final String DEFAULT_COMMENT_CONTENT = "No comments";
 
   private CommentDataStore commentDataStore;

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -29,6 +29,11 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/comment")
 public final class NewCommentServlet extends HttpServlet {
 
+  private final static String PARAM_NAME_COMMENTER = "commenter";
+  private final static String PARAM_NAME_CONTENT = "content";
+  private static final String DEFAULT_COMMENT_COMMENTER = "";
+  private static final String DEFAULT_COMMENT_CONTENT = "No comments";
+
   private CommentDataStore commentDataStore;
 
   @Override
@@ -36,16 +41,11 @@ public final class NewCommentServlet extends HttpServlet {
     this.commentDataStore = new CommentDataStore(DatastoreServiceFactory.getDatastoreService());
   }
 
-  private final static String PARAM_NAME_COMMENTER = "commenter";
-  private final static String PARAM_NAME_CONTENT = "content";
-
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Gets comments from the form
-    String commenter = ServletUtils.getParameter(
-            request, PARAM_NAME_COMMENTER, /*defaultValue=*/"");
-    String content = ServletUtils.getParameter(
-            request, PARAM_NAME_CONTENT, /*defaultValue=*/"No comments");
+    String commenter = ServletUtils.getParameter(request, PARAM_NAME_COMMENTER, DEFAULT_COMMENT_COMMENTER);
+    String content = ServletUtils.getParameter(request, PARAM_NAME_CONTENT, DEFAULT_COMMENT_CONTENT);
     // TODO: validate request parameters
 
     // Stores the comment into the Datastore

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -15,81 +15,20 @@
 package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.*;
-import com.google.gson.Gson;
 import com.google.sps.data.Comment;
 
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.google.sps.utils.Constants.COMMENT_COMMENTER;
 import static com.google.sps.utils.Constants.COMMENT_CONTENT;
 import static com.google.sps.utils.Constants.COMMENT_KEY;
-import static com.google.sps.utils.Constants.COMMENT_MAXNUMBER;
-import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
 
 /** Servlet that handles getting comment content. */
 @WebServlet("/comment")
 public final class NewCommentServlet extends CommentServlet {
-
-//  private int maxNumberOfComments;
-//
-//  @Override
-//  public void init() {
-//    this.maxNumberOfComments = 10; // default value
-//  }
-//
-//  @Override
-//  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-//    // Loads the comment from Datastore
-//    List<Comment> comments = getComments();
-//
-//    // Converts into json form
-//    String json = convertToJsonUsingGson(comments);
-//
-//    // Sends the JSON as the response
-//    sendJsonResponse(response, json);
-//  }
-
-//  /** Loads the comment from Datastore */
-//  private List<Comment> getComments() {
-//    Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
-//
-//    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
-//    PreparedQuery results = datastoreService.prepare(query);
-//
-//    List<Comment> comments = new ArrayList<>();
-//    for (Entity entity: results.asIterable()) {
-//      if (comments.size() > this.maxNumberOfComments) {
-//        break;
-//      }
-//
-//      // Loads comments from Datastore
-//      Comment comment = Comment.CREATOR.fromEntity(entity);
-//      comments.add(comment);
-//    }
-//
-//    return comments;
-//  }
-//
-//  /** Converts the list of Comment objecct into json form */
-//  private String convertToJsonUsingGson(List<Comment> comments) {
-//    Gson gson = new Gson();
-//    String json = gson.toJson(comments);
-//    return json;
-//  }
-//
-//  /** Sends the JSON as response */
-//  private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
-//    response.setContentType("application/json;");
-//    response.getWriter().println(json);
-//  }
-
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Gets comments from the form

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -36,18 +36,16 @@ public final class NewCommentServlet extends HttpServlet {
     this.commentDataStore = new CommentDataStore(DatastoreServiceFactory.getDatastoreService());
   }
 
-  static class Constants {
-    private final static String PARAM_NAME_COMMENTER = "commenter";
-    private final static String PARAM_NAME_CONTENT = "content";
-  }
+  private final static String PARAM_NAME_COMMENTER = "commenter";
+  private final static String PARAM_NAME_CONTENT = "content";
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Gets comments from the form
     String commenter = ServletUtils.getParameter(
-            request, /*name=*/Constants.PARAM_NAME_COMMENTER, /*defaultValue=*/"");
+            request, PARAM_NAME_COMMENTER, /*defaultValue=*/"");
     String content = ServletUtils.getParameter(
-            request, /*name=*/Constants.PARAM_NAME_CONTENT, /*defaultValue=*/"No comments");
+            request, PARAM_NAME_CONTENT, /*defaultValue=*/"No comments");
     // TODO: validate request parameters
 
     // Stores the comment into the Datastore

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -1,0 +1,117 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.*;
+import com.google.gson.Gson;
+import com.google.sps.data.Comment;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.sps.utils.Constants.COMMENT_COMMENTER;
+import static com.google.sps.utils.Constants.COMMENT_CONTENT;
+import static com.google.sps.utils.Constants.COMMENT_KEY;
+import static com.google.sps.utils.Constants.COMMENT_MAXNUMBER;
+import static com.google.sps.utils.Constants.COMMENT_TIMESTAMP;
+
+/** Servlet that handles getting comment content. */
+@WebServlet("/comment")
+public final class NewCommentServlet extends CommentServlet {
+
+//  private int maxNumberOfComments;
+//
+//  @Override
+//  public void init() {
+//    this.maxNumberOfComments = 10; // default value
+//  }
+//
+//  @Override
+//  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+//    // Loads the comment from Datastore
+//    List<Comment> comments = getComments();
+//
+//    // Converts into json form
+//    String json = convertToJsonUsingGson(comments);
+//
+//    // Sends the JSON as the response
+//    sendJsonResponse(response, json);
+//  }
+
+//  /** Loads the comment from Datastore */
+//  private List<Comment> getComments() {
+//    Query query = new Query(COMMENT_KEY).addSort(COMMENT_TIMESTAMP, Query.SortDirection.DESCENDING);
+//
+//    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+//    PreparedQuery results = datastoreService.prepare(query);
+//
+//    List<Comment> comments = new ArrayList<>();
+//    for (Entity entity: results.asIterable()) {
+//      if (comments.size() > this.maxNumberOfComments) {
+//        break;
+//      }
+//
+//      // Loads comments from Datastore
+//      Comment comment = Comment.CREATOR.fromEntity(entity);
+//      comments.add(comment);
+//    }
+//
+//    return comments;
+//  }
+//
+//  /** Converts the list of Comment objecct into json form */
+//  private String convertToJsonUsingGson(List<Comment> comments) {
+//    Gson gson = new Gson();
+//    String json = gson.toJson(comments);
+//    return json;
+//  }
+//
+//  /** Sends the JSON as response */
+//  private void sendJsonResponse(HttpServletResponse response, String json) throws IOException {
+//    response.setContentType("application/json;");
+//    response.getWriter().println(json);
+//  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Gets comments from the form
+    String commenter = getParameter(request, /*name=*/COMMENT_COMMENTER, /*defaultValue=*/"");
+    String content = getParameter(request, /*name=*/COMMENT_CONTENT, /*defaultValue=*/"No comments");
+    // TODO: validate request parameters
+
+    // Stores the comment into the Datastore
+    storeComment(commenter, content);
+
+    // Redirects back to the HTML page.
+    response.sendRedirect("/index.html");
+  }
+
+  /** Stores the comment into the Datastore */
+  private void storeComment(String commenter, String content) {
+    // create a miscellaneous comment object to convert it to entity
+    long timestamp = System.currentTimeMillis();
+    Comment comment = new Comment(0, commenter, content, timestamp);
+
+    // put the entity into Datastore
+    DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+    datastoreService.put(comment.toEntity(COMMENT_KEY));
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/utils/CommentDataStore.java
+++ b/portfolio/src/main/java/com/google/sps/utils/CommentDataStore.java
@@ -2,6 +2,7 @@ package com.google.sps.utils;
 
 import com.google.appengine.api.datastore.*;
 import com.google.sps.data.Comment;
+import com.google.sps.data.EntityConvertible;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,8 +10,8 @@ import java.util.List;
 /** Provides the service to interact with Datastore to store or load comment. */
 public class CommentDataStore implements ObjectDataStore<Comment> {
 
-    private final static String KIND = "Comment";
-    private final static String TIMESTAMP = "timestamp";
+    private static final String KIND = "Comment";
+    private static final String TIMESTAMP = "timestamp";
 
     private DatastoreService datastoreService;
 
@@ -36,13 +37,10 @@ public class CommentDataStore implements ObjectDataStore<Comment> {
 
         Query query = new Query(KIND).addSort(TIMESTAMP, Query.SortDirection.DESCENDING);
         PreparedQuery results = this.datastoreService.prepare(query);
+        Iterable<Entity> resultsIterable = results.asIterable(FetchOptions.Builder.withLimit(limit));
 
         List<Comment> comments = new ArrayList<>();
-        for (Entity entity: results.asIterable()) {
-            if (comments.size() >= limit) {
-                break;
-            }
-
+        for (Entity entity: resultsIterable) {
             Comment comment = Comment.CREATOR.fromEntity(entity);
             comments.add(comment);
         }

--- a/portfolio/src/main/java/com/google/sps/utils/CommentDataStore.java
+++ b/portfolio/src/main/java/com/google/sps/utils/CommentDataStore.java
@@ -1,19 +1,16 @@
 package com.google.sps.utils;
 
 import com.google.appengine.api.datastore.*;
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
 import com.google.sps.data.Comment;
-import com.google.sps.data.EntityConvertible;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /** Provides the service to interact with Datastore to store or load comment. */
-public class CommentDataStore implements ObjectDataStore<Comment> {
+public final class CommentDataStore implements ObjectDataStore<Comment> {
 
     private static final String KIND = "Comment";
     private static final String TIMESTAMP = "timestamp";
 
-    private DatastoreService datastoreService;
+    private final DatastoreService datastoreService;
 
     public CommentDataStore(DatastoreService datastoreService) {
         this.datastoreService = datastoreService;
@@ -30,21 +27,18 @@ public class CommentDataStore implements ObjectDataStore<Comment> {
 
     /**
      * Loads the comments from Datastore.
-     * @return An Iterable.
+     * @return An immutable list of comments.
      */
     @Override
-    public List<Comment> load(int limit) {
-
+    public ImmutableList<Comment> load(int limit) {
         Query query = new Query(KIND).addSort(TIMESTAMP, Query.SortDirection.DESCENDING);
         PreparedQuery results = this.datastoreService.prepare(query);
         Iterable<Entity> resultsIterable = results.asIterable(FetchOptions.Builder.withLimit(limit));
 
-        List<Comment> comments = new ArrayList<>();
-        for (Entity entity: resultsIterable) {
-            Comment comment = Comment.CREATOR.fromEntity(entity);
-            comments.add(comment);
+        ImmutableList.Builder<Comment> comments = ImmutableList.builder();
+        for( Entity entity: resultsIterable){
+            comments.add(Comment.CREATOR.fromEntity(entity));
         }
-
-        return comments;
+        return comments.build();
     }
 }

--- a/portfolio/src/main/java/com/google/sps/utils/CommentDataStore.java
+++ b/portfolio/src/main/java/com/google/sps/utils/CommentDataStore.java
@@ -41,6 +41,10 @@ public class CommentDataStore {
 
             List<Comment> comments = new ArrayList<>();
             for (Entity entity: results.asIterable()) {
+                if (comments.size() >= limit) {
+                    break;
+                }
+
                 Comment comment = Comment.CREATOR.fromEntity(entity);
                 comments.add(comment);
             }

--- a/portfolio/src/main/java/com/google/sps/utils/Constants.java
+++ b/portfolio/src/main/java/com/google/sps/utils/Constants.java
@@ -5,4 +5,5 @@ public class Constants {
     public final static String COMMENT_COMMENTER = "commenter";
     public final static String COMMENT_CONTENT = "content";
     public final static String COMMENT_TIMESTAMP = "timestamp";
+    public final static String COMMENT_MAXNUMBER = "quantity";
 }

--- a/portfolio/src/main/java/com/google/sps/utils/ObjectDataStore.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ObjectDataStore.java
@@ -1,6 +1,6 @@
 package com.google.sps.utils;
 
-import java.util.List;
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
 
 /** Interface for classes whose instances can be written to and restored from Datastore.
  * Classes implementing the ObjectDataStore interface must also have a non-null static field called CREATOR of a type
@@ -15,7 +15,7 @@ public interface ObjectDataStore<T> {
     /**
      * Loads the object from Datastore.
      * @param limit Upper limit of number of objects.
-     * @return An list of objects.
+     * @return An immutable list of objects.
      */
-    public List<T> load(int limit);
+    public ImmutableList<T> load(int limit);
 }

--- a/portfolio/src/main/java/com/google/sps/utils/ObjectDataStore.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ObjectDataStore.java
@@ -14,7 +14,7 @@ public interface ObjectDataStore<T> {
 
     /**
      * Loads the object from Datastore.
-     * @param limit Upper limit of objects in the list.
+     * @param limit Upper limit of number of objects.
      * @return An list of objects.
      */
     public List<T> load(int limit);

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -23,13 +23,13 @@ public class ServletUtils {
      * Gets the integer parameter from html form input.
      * @param request Http request.
      * @param parameterName Input id in html element.
-     * @param defaultValue Default integer string.
-     * @return Parsed integer or -1.
+     * @param defaultValue Default integer.
+     * @return Parsed integer or default value if exception occur
      */
-    public static int getIntParameter(HttpServletRequest request, String parameterName, String defaultValue) {
-        String maxNumOfCommentStr = ServletUtils.getParameter(request, parameterName, defaultValue);
+    public static int getIntParameter(HttpServletRequest request, String parameterName, int defaultValue) {
+        String maxNumOfCommentStr = request.getParameter(parameterName);
 
-        int result = -1;
+        int result = defaultValue;
 
         try {
             result = Integer.parseInt(maxNumOfCommentStr);

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -1,8 +1,6 @@
 package com.google.sps.utils;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 /** Auxiliary functions and variables to support comment feature. */
 public class ServletUtils {
@@ -29,8 +27,7 @@ public class ServletUtils {
      * @return Parsed integer or -1.
      */
     public static int getIntParameter(HttpServletRequest request, String parameterName, String defaultValue) {
-        String maxNumOfCommentStr = ServletUtils.getParameter(
-                request, parameterName, defaultValue);
+        String maxNumOfCommentStr = ServletUtils.getParameter(request, parameterName, defaultValue);
 
         int result = -1;
 

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -38,6 +38,7 @@ public class ServletUtils {
 
             return result;
         } catch (NumberFormatException e) {
+            // TODO: error handling
             System.err.println("Could not convert to int: " + resultStr);
             // TODO: add logging to log the error
 

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -35,6 +35,7 @@ public class ServletUtils {
             result = Integer.parseInt(maxNumOfCommentStr);
         } catch (NumberFormatException e) {
             System.err.println("Could not convert to int: " + maxNumOfCommentStr);
+            // TODO: add logging to log the error
 
             return result;
         }

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -1,6 +1,8 @@
 package com.google.sps.utils;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 /** Auxiliary functions and variables to support comment feature. */
 public class ServletUtils {
@@ -17,5 +19,29 @@ public class ServletUtils {
             return defaultValue;
         }
         return value;
+    }
+
+    /**
+     * Gets the integer parameter from html form input.
+     * @param request Http request.
+     * @param parameterName Input id in html element.
+     * @param defaultValue Default integer string.
+     * @return Parsed integer or -1.
+     */
+    public static int getIntParameter(HttpServletRequest request, String parameterName, String defaultValue) {
+        String maxNumOfCommentStr = ServletUtils.getParameter(
+                request, parameterName, defaultValue);
+
+        int result = -1;
+
+        try {
+            result = Integer.parseInt(maxNumOfCommentStr);
+        } catch (NumberFormatException e) {
+            System.err.println("Could not convert to int: " + maxNumOfCommentStr);
+
+            return result;
+        }
+
+        return result;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -30,7 +30,13 @@ public class ServletUtils {
         String resultStr = request.getParameter(parameterName);
 
         try {
-            return Integer.parseInt(resultStr);
+            int result = Integer.parseInt(resultStr);
+
+            if (result < 0 || result > 10) {
+                throw new NumberFormatException("Please enter an integer between 1 and 10.");
+            }
+
+            return result;
         } catch (NumberFormatException e) {
             System.err.println("Could not convert to int: " + resultStr);
             // TODO: add logging to log the error

--- a/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
+++ b/portfolio/src/main/java/com/google/sps/utils/ServletUtils.java
@@ -27,19 +27,15 @@ public class ServletUtils {
      * @return Parsed integer or default value if exception occur
      */
     public static int getIntParameter(HttpServletRequest request, String parameterName, int defaultValue) {
-        String maxNumOfCommentStr = request.getParameter(parameterName);
-
-        int result = defaultValue;
+        String resultStr = request.getParameter(parameterName);
 
         try {
-            result = Integer.parseInt(maxNumOfCommentStr);
+            return Integer.parseInt(resultStr);
         } catch (NumberFormatException e) {
-            System.err.println("Could not convert to int: " + maxNumOfCommentStr);
+            System.err.println("Could not convert to int: " + resultStr);
             // TODO: add logging to log the error
 
-            return result;
+            return defaultValue;
         }
-
-        return result;
     }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -58,10 +58,8 @@
       <form action="/list-comment" method="post" onsubmit="loadAndShowData()">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
-        <input type="submit" value="Submit Your Choice">
+        <button>Submit</button>
       </form>
-
-      <button onclick="loadAndShowData()">Show Comments</button>
 
       <div id="comments"></div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -57,17 +57,13 @@
 
       <form action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <select id="quantity" onchange="loadAndShowComments()">
-          <script>
-            for (let i = 1; i <= 10; i++) {
-              let option = document.createElement("option");
-              let attribute = document.createAttribute("value");
-              attribute.value = "" + i;
-              option.setAttribute(attribute);
-              option.innerHTML = "" + i;
-            }
-          </script>
-        </select>
+        <input list="quantities" name="quantity" id="quantity">
+        <datalist id="quantities">
+          <option value="1">
+          <option value="2">
+        </datalist>
+
+        <input type="submit" value="Submit Your Choice" onsubmit="loadAndShowComments()">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,10 +55,19 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form id="quantityForm" action="/list-comment" method="post">
+      <form action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="10">
-        <input type="button" value="Submit Your Choice" onclick="loadAndShowComments()">
+        <select id="quantity" onchange="loadAndShowComments()">
+          <script>
+            for (let i = 1; i <= 10; i++) {
+              let option = document.createElement("option");
+              let attribute = document.createAttribute("value");
+              attribute.value = "" + i;
+              option.setAttribute(attribute);
+              option.innerHTML = "" + i;
+            }
+          </script>
+        </select>
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,7 +55,7 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="post">
+      <form action="/list-comment" method="get">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,9 +55,10 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="post">
+      <form action="/list-comment" method="post" onsubmit="loadAndShowData()">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="10" onchange="this.form.submit()">
+        <input type="number" id="quantity" name="quantity" min="1" max="10">
+        <input type="submit" value="Submit Your Choice">
       </form>
 
       <button onclick="loadAndShowData()">Show Comments</button>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -59,7 +59,7 @@
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 
-        <button>Submit Your Choice</button>
+        <input type="submit" value="Submit Your Choice">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -57,9 +57,10 @@
 
       <form action="/list-comment" method="get">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="10">
-        <input type="submit" value="Submit Your Choice" onchange="loadAndShowData()">
+        <input type="number" id="quantity" name="quantity" min="1" max="10" onchange="this.form.submit()">
       </form>
+
+      <button onclick="loadAndShowData()">Show Comments</button>
 
       <div id="comments"></div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,10 +55,10 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="post">
+      <form id="quantityForm" action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="10" onchange="this.form.submit()">
-        <button onclick="loadAndShowData()">Submit</button>
+        <input type="number" id="quantity" name="quantity" min="1" max="10">
+        <input type="button" value="Submit Your Choice" onclick="loadAndShowComments()">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
-  <body onload="loadAndShowComments()">
+  <body>
     <div id="content">
       <h1>Wu Sibing's Portfolio</h1>
       <p>This is my portfolio.</p>
@@ -59,7 +59,7 @@
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 
-        <input type="submit" value="Submit Your Choice">
+        <input type="button" value="Submit Your Choice" onclick="loadAndShowComments()">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -61,8 +61,6 @@
         <input type="submit" value="Submit Your Choice" onchange="loadAndShowData()">
       </form>
 
-
-
       <div id="comments"></div>
     </div>
   </body>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -57,11 +57,7 @@
 
       <form action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input list="quantities" name="quantity" id="quantity">
-        <datalist id="quantities">
-          <option value="1">
-          <option value="2">
-        </datalist>
+        <input type="number" id="quantity" name="quantity" min="1" max="3">
 
         <input type="submit" value="Submit Your Choice">
       </form>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
-  <body onload="loadAndShowComments()">
+  <body>
     <div id="content">
       <h1>Wu Sibing's Portfolio</h1>
       <p>This is my portfolio.</p>
@@ -55,11 +55,11 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="get">
+      <form action="/list-comment" method="get" id="get-limit">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 
-        <input type="submit" value="Submit Your Choice">
+        <input type="button" value="Submit Your Choice">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
-  <body>
+  <body onload="loadAndShowComments()">
     <div id="content">
       <h1>Wu Sibing's Portfolio</h1>
       <p>This is my portfolio.</p>
@@ -63,7 +63,7 @@
           <option value="2">
         </datalist>
 
-        <input type="submit" value="Submit Your Choice" onsubmit="loadAndShowComments()">
+        <input type="submit" value="Submit Your Choice">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -59,7 +59,7 @@
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 
-        <input type="button" value="Submit Your Choice">
+        <input type="button" value="Submit Your Choice" onclick="loadAndShowComments()">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -59,7 +59,7 @@
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 
-        <input type="submit" value="Submit Your Choice">
+        <button>Submit Your Choice</button>
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,10 +55,10 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="post" onsubmit="loadAndShowData()">
+      <form action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="10">
-        <button>Submit</button>
+        <input type="number" id="quantity" name="quantity" min="1" max="10" onchange="this.form.submit()">
+        <button onclick="loadAndShowData()">Submit</button>
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -57,7 +57,7 @@
 
       <form action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="3">
+        <input type="number" id="quantity" name="quantity" min="1" max="10">
 
         <input type="submit" value="Submit Your Choice">
       </form>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,7 +55,7 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="post">
+      <form action="/list-comment" method="get">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
         <input type="submit" value="Submit Your Choice" onchange="loadAndShowData()">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -53,13 +53,15 @@
         <label for="content">Comment</label><br>
         <input type="text" id="contentText" name="content" size="50"><br>
         <input type="submit" value="Submit Your Comment">
-
-        <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
-        <input type="number" id="quantity" name="quantity" min="1" max="10">
-
       </form>
 
-      <button onclick="loadAndShowData()">Show Comments</button>
+      <form action="/list-comment" method="post">
+        <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
+        <input type="number" id="quantity" name="quantity" min="1" max="10">
+        <input type="submit" value="Submit Your Choice" onchange="loadAndShowData()">
+      </form>
+
+
 
       <div id="comments"></div>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -51,7 +51,7 @@
         <label for="commenter">Commenter Name</label>
         <input type="text" id="commenter" name="commenter"><br>
         <label for="content">Comment</label><br>
-        <input type="text" id="contentText" name="content" size="50"><br>
+        <input type="text" id="contentText" name="content" size="50" required><br>
         <input type="submit" value="Submit Your Comment">
       </form>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,7 +55,7 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="get" id="get-limit">
+      <form action="/list-comment" method="get">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -53,9 +53,14 @@
         <label for="content">Comment</label><br>
         <input type="text" id="contentText" name="content" size="50"><br>
         <input type="submit" value="Submit Your Comment">
+
+        <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
+        <input type="number" id="quantity" name="quantity" min="1" max="10">
+
       </form>
 
       <button onclick="loadAndShowData()">Show Comments</button>
+
       <div id="comments"></div>
     </div>
   </body>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -55,7 +55,7 @@
         <input type="submit" value="Submit Your Comment">
       </form>
 
-      <form action="/list-comment" method="get">
+      <form action="/list-comment" method="post">
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10" onchange="this.form.submit()">
       </form>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="script.js"></script>
   </head>
-  <body>
+  <body onload="loadAndShowComments()">
     <div id="content">
       <h1>Wu Sibing's Portfolio</h1>
       <p>This is my portfolio.</p>
@@ -59,7 +59,7 @@
         <label for="quantity">Please select the number of comments you want to show (between 1 and 10):</label>
         <input type="number" id="quantity" name="quantity" min="1" max="10">
 
-        <input type="button" value="Submit Your Choice" onclick="loadAndShowComments()">
+        <input type="submit" value="Submit Your Choice">
       </form>
 
       <div id="comments"></div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -90,8 +90,7 @@ function loadAndShowComments() {
     if (maxNumberOfComments.length == 0) {
         return;
     }
-    let url = "/list-comment?quantity=" + maxNumberOfComments;
-    console.log(url);
+    let url = "/list-comment?quantity=" + maxNumberOfComments;ss
     fetch(url, {method: "GET"}).then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";
@@ -101,7 +100,6 @@ function loadAndShowComments() {
             div.appendChild(createListElement(commentString));
         }
     });
-    window.location = "index.html";
 }
 
 /** Creates an <li> element containing text. */

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -87,6 +87,9 @@ function goBack() {
  */
 function loadAndShowComments() {
     let maxNumberOfComments = document.getElementById("quantity").value;
+    if (maxNumberOfComments.length == 0) {
+        maxNumberOfComments = 0;
+    }
     const url = "/list-comment?quantity=" + maxNumberOfComments;
     fetch(url).then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,6 +86,8 @@ function goBack() {
  * Fetches the response of "/data".
  */
 function loadAndShowComments() {
+    document.getElementById("get-limit").submit();
+
     fetch("/list-comment").then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -87,6 +87,7 @@ function goBack() {
  */
 function loadAndShowData() {
     fetch("/list-comment").then(response => response.json()).then((json) => {
+        console.log(json);
         const div = document.getElementById("comments");
         div.innerHTML = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -85,7 +85,9 @@ function goBack() {
 /**
  * Fetches the response of "/data".
  */
-function loadAndShowData() {
+function loadAndShowComments() {
+    document.getElementById("quantityForm").submit();
+
     fetch("/list-comment").then(response => response.json()).then((json) => {
         console.log(json);
         const div = document.getElementById("comments");

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -88,7 +88,7 @@ function goBack() {
 function loadAndShowComments() {
     let maxNumberOfComments = document.getElementById("quantity").value;
     if (maxNumberOfComments.length == 0) {
-        maxNumberOfComments = 0;
+        return;
     }
     const url = "/list-comment?quantity=" + maxNumberOfComments;
     fetch(url).then(response => response.json()).then((json) => {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,8 +86,6 @@ function goBack() {
  * Fetches the response of "/data".
  */
 function loadAndShowComments() {
-    // document.getElementById("quantityForm").submit();
-
     fetch("/list-comment").then(response => response.json()).then((json) => {
         console.log(json);
         const div = document.getElementById("comments");
@@ -98,8 +96,6 @@ function loadAndShowComments() {
             div.appendChild(createListElement(commentString));
         }
     });
-
-    window.location = "/index.html";
 }
 
 /** Creates an <li> element containing text. */

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,7 +86,7 @@ function goBack() {
  * Fetches the response of "/data".
  */
 function loadAndShowComments() {
-    document.getElementById("quantityForm").submit();
+    // document.getElementById("quantityForm").submit();
 
     fetch("/list-comment").then(response => response.json()).then((json) => {
         console.log(json);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -90,7 +90,7 @@ function loadAndShowComments() {
     if (maxNumberOfComments.length == 0) {
         return;
     }
-    let url = "/list-comment?quantity=" + maxNumberOfComments;ss
+    let url = "/list-comment?quantity=" + maxNumberOfComments;
     fetch(url, {method: "GET"}).then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,7 +86,9 @@ function goBack() {
  * Fetches the response of "/data".
  */
 function loadAndShowComments() {
-    fetch("/list-comment?quantity=2").then(response => response.json()).then((json) => {
+    let maxNumberOfComments = document.getElementById("quantity").value;
+    const url = "/list-comment?quantity=" + maxNumberOfComments;
+    fetch(url).then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,9 +86,7 @@ function goBack() {
  * Fetches the response of "/data".
  */
 function loadAndShowComments() {
-    document.getElementById("get-limit").submit();
-
-    fetch("/list-comment").then(response => response.json()).then((json) => {
+    fetch("/list-comment?quantity=2").then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -92,7 +92,7 @@ function loadAndShowComments() {
     }
     let url = "/list-comment?quantity=" + maxNumberOfComments;
     console.log(url);
-    fetch(url).then(response => response.json()).then((json) => {
+    fetch(url, {method: "GET"}).then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -76,7 +76,7 @@ function getRandomFact(facts, currentFact) {
 function goBack() {
     // If this is the first page.
     if(history.length === 1){
-        window.location = "index.html"
+        window.location = "index.html";
     } else {
         history.back();
     }
@@ -101,6 +101,7 @@ function loadAndShowComments() {
             div.appendChild(createListElement(commentString));
         }
     });
+    window.location = "index.html";
 }
 
 /** Creates an <li> element containing text. */

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -98,6 +98,8 @@ function loadAndShowComments() {
             div.appendChild(createListElement(commentString));
         }
     });
+
+    window.location = "/index.html";
 }
 
 /** Creates an <li> element containing text. */

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -87,7 +87,6 @@ function goBack() {
  */
 function loadAndShowComments() {
     fetch("/list-comment").then(response => response.json()).then((json) => {
-        console.log(json);
         const div = document.getElementById("comments");
         div.innerHTML = "";
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,7 +86,7 @@ function goBack() {
  * Fetches the response of "/data".
  */
 function loadAndShowData() {
-    fetch("/comment").then(response => response.json()).then((json) => {
+    fetch("/list-comment").then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";
 
@@ -115,7 +115,6 @@ function getFormattedComment(json) {
     let timestamp = json.timestamp;
 
     let timeString = getFormattedDate(timestamp);
-
 
     let resultString = `Commenter: ${commenter}\nTime: ${timeString}\nComment: ${content}`;
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -90,7 +90,8 @@ function loadAndShowComments() {
     if (maxNumberOfComments.length == 0) {
         return;
     }
-    const url = "/list-comment?quantity=" + maxNumberOfComments;
+    let url = "/list-comment?quantity=" + maxNumberOfComments;
+    console.log(url);
     fetch(url).then(response => response.json()).then((json) => {
         const div = document.getElementById("comments");
         div.innerHTML = "";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -88,7 +88,7 @@ function goBack() {
 function loadAndShowComments() {
     let maxNumberOfComments = document.getElementById("quantity").value;
     if (maxNumberOfComments.length == 0) {
-        return;
+        maxNumberOfComments = 0;
     }
     let url = "/list-comment?quantity=" + maxNumberOfComments;
     fetch(url, {method: "GET"}).then(response => response.json()).then((json) => {


### PR DESCRIPTION
## Description

Let the user select how many comments should be fetched and displayed. Users are given a way to refresh the comments section when they make a selection.

Fixes #28
Screenshot:
![image](https://user-images.githubusercontent.com/49228945/83991767-714cfb80-a980-11ea-92ce-56f532a73988.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test
Manual Test